### PR TITLE
Support exposing multiple services per pod

### DIFF
--- a/demo/rc.yaml
+++ b/demo/rc.yaml
@@ -15,8 +15,7 @@ spec:
         microservice: "true"
       annotations:
         trafficHosts: "test.k8s.local"
-        publicPaths: "/nodejs"
-        pathPort: "3000"
+        publicPaths: "3000:/nodejs"
     spec:
       containers:
       - name: nodejs-k8s-env

--- a/ingress/pods.go
+++ b/ingress/pods.go
@@ -4,38 +4,95 @@ import (
 	"log"
 	"strconv"
 
+	"regexp"
+	"strings"
+
 	"k8s.io/kubernetes/pkg/api"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/watch"
-	"regexp"
-	"strings"
 )
 
 const (
 	// KeyMicroserviceL is the label used to identify microservices
 	KeyMicroserviceL = "microservice"
-	// KeyPathPortA is the annotation used to identify the pod port used for the microservice
-	KeyPathPortA = "pathPort"
 	// KeyPublicPathsA is the annotation used to identify the list of traffic paths associated with the microservice
 	KeyPublicPathsA = "publicPaths"
 	// KeyTrafficHostsA is the annotation used to identify the list of traffic hosts associated with the microservice
-	KeyTrafficHostsA = "trafficHosts"
-	hostnameRegex    = "^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$"
-	ipRegex          = "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$"
+	KeyTrafficHostsA    = "trafficHosts"
+	hostnameRegexStr    = "^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$"
+	ipRegexStr          = "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$"
+	pathSegmentRegexStr = "^[A-Za-z0-9\\-._~!$&'()*+,;=:@]|%[0-9A-Fa-f]{2}$"
 )
+
+/*
+Incoming describes the information required to route an incoming request
+*/
+type Incoming struct {
+	Host string
+	Path string
+}
+
+/*
+Outgoing describes the information required to proxy to a backend
+*/
+type Outgoing struct {
+	IP   string
+	Port string
+}
+
+/*
+PodWithRoutes contains a pod and its routes
+*/
+type PodWithRoutes struct {
+	Pod    *api.Pod
+	Routes []*Route
+}
+
+/*
+Route describes the incoming route matching details and the outgoing proxy backend details
+*/
+type Route struct {
+	Incoming *Incoming
+	Outgoing *Outgoing
+}
+
+type pathPair struct {
+	Path string
+	Port string
+}
+
+/*
+String implements the Stringer interface
+*/
+func (r *Route) String() string {
+	return r.Incoming.Host + r.Incoming.Path + " -> " + r.Outgoing.IP + ":" + r.Outgoing.Port
+}
 
 /*
 MicroserviceLabelSelector is the label selector to identify microservice pods.
 */
 var MicroserviceLabelSelector labels.Selector
+var hostnameRegex *regexp.Regexp
+var ipRegex *regexp.Regexp
+var pathSegmentRegex *regexp.Regexp
+
+func compileRegex(regexStr string) *regexp.Regexp {
+	compiled, err := regexp.Compile(regexStr)
+
+	if err != nil {
+		log.Fatalf("Failed to compile regular expression (%s): %v\n", regexStr, err)
+	}
+
+	return compiled
+}
 
 func filterPods(pods []api.Pod) []api.Pod {
 	var filtered []api.Pod
 
 	for _, pod := range pods {
-		if IsPodRoutable(pod) {
+		if len(GetRoutes(&pod)) > 0 {
 			filtered = append(filtered, pod)
 		}
 	}
@@ -52,18 +109,11 @@ func init() {
 	}
 
 	MicroserviceLabelSelector = selector
-}
 
-func matches(regex, value string) bool {
-	match, err := regexp.MatchString(regex, value)
-
-	if err != nil {
-		log.Printf("Error matching regex (%s): %v\n", regex, err)
-
-		match = false
-	}
-
-	return match
+	// Compile all regular expressions
+	hostnameRegex = compileRegex(hostnameRegexStr)
+	ipRegex = compileRegex(ipRegexStr)
+	pathSegmentRegex = compileRegex(pathSegmentRegexStr)
 }
 
 /*
@@ -87,121 +137,189 @@ func GetMicroservicePodList(kubeClient *client.Client) (*api.PodList, error) {
 }
 
 /*
-IsPodRoutable returns whether or not the pod is routable.
+GetRoutes returns an array of routes defined within the provided pod
 */
-func IsPodRoutable(pod api.Pod) bool {
-	routable := true
+func GetRoutes(pod *api.Pod) []*Route {
+	var routes []*Route
 
 	// Do not process pods that are not running
-	if pod.Status.Phase != api.PodRunning {
-		log.Printf("  Pod (%s) is not routable: Not running (%s)\n", pod.Name, pod.Status.Phase)
-		routable = false
-	}
+	if pod.Status.Phase == api.PodRunning {
+		var hosts []string
+		var pathPairs []*pathPair
 
-	if routable {
 		annotation, ok := pod.ObjectMeta.Annotations[KeyTrafficHostsA]
 
 		// This pod does not have the trafficHosts annotation set
-		if !ok {
-			log.Printf("  Pod (%s) is not routable: Missing '%s' annotation\n", pod.Name, KeyTrafficHostsA)
-			routable = false
-		}
-
-		for _, host := range strings.Split(annotation, " ") {
-			valid := matches(hostnameRegex, host)
-
-			if !valid {
-				valid = matches(ipRegex, host)
+		if ok {
+			// Process the routing hosts
+			for _, host := range strings.Split(annotation, " ") {
+				valid := hostnameRegex.MatchString(host)
 
 				if !valid {
-					log.Printf("  Pod (%s) is not routable: trafficHosts annotation (%s) is not a valid hostname/ip\n", pod.Name, host)
-					routable = false
+					valid = ipRegex.MatchString(host)
 
-					break
+					if !valid {
+						log.Printf("    Pod (%s) routing issue: trafficHost (%s) is not a valid hostname/ip\n", pod.Name, host)
+
+						continue
+					}
+				}
+
+				// Record the host
+				hosts = append(hosts, host)
+			}
+
+			// Do not process the routing paths if there are no valid hosts
+			if len(hosts) > 0 {
+				annotation, ok = pod.ObjectMeta.Annotations[KeyPublicPathsA]
+
+				if ok {
+					for _, publicPath := range strings.Split(annotation, " ") {
+						pathParts := strings.Split(publicPath, ":")
+
+						if len(pathParts) == 2 {
+							cPathPair := &pathPair{}
+
+							// Validate the port
+							port, err := strconv.Atoi(pathParts[0])
+
+							if err == nil && port > 0 && port < 65536 {
+								cPathPair.Port = pathParts[0]
+							} else {
+								log.Printf("    Pod (%s) routing issue: publicPath port (%s) is not valid\n", pod.Name, pathParts[0])
+							}
+
+							// Validate the path (when necessary)
+							if port > 0 {
+								pathSegments := strings.Split(pathParts[1], "/")
+								valid := true
+
+								for i, pathSegment := range pathSegments {
+									// Skip the first and last entry
+									if (i == 0 || i == len(pathParts)-1) && pathSegment == "" {
+										continue
+									} else if !pathSegmentRegex.MatchString(pathSegment) {
+										log.Printf("    Pod (%s) routing issue: publicPath path (%s) is not a valid\n", pod.Name, pathParts[0])
+
+										valid = false
+
+										break
+									}
+								}
+
+								if valid {
+									cPathPair.Path = pathParts[1]
+								}
+							}
+
+							if cPathPair.Path != "" && cPathPair.Port != "" {
+								pathPairs = append(pathPairs, cPathPair)
+							}
+						} else {
+							log.Printf("    Pod (%s) routing issue: publicPath (%s) is not a valid PORT:PATH combination\n", pod.Name, annotation)
+						}
+					}
+				} else {
+					log.Printf("    Pod (%s) is not routable: Missing '%s' annotation\n", pod.Name, KeyPublicPathsA)
 				}
 			}
-		}
-	}
 
-	if routable {
-		annotation, ok := pod.ObjectMeta.Annotations[KeyPathPortA]
-
-		if ok {
-			_, err := strconv.Atoi(annotation)
-
-			if err != nil {
-				log.Printf("  Pod (%s) is not routable: Invalid '%s' value (%s): %v.\n",
-					pod.Name, KeyPathPortA, annotation, err)
-				routable = false
+			// Turn the hosts and path pairs into routes
+			if hosts != nil && pathPairs != nil {
+				for _, host := range hosts {
+					for _, cPathPair := range pathPairs {
+						routes = append(routes, &Route{
+							Incoming: &Incoming{
+								Host: host,
+								Path: cPathPair.Path,
+							},
+							Outgoing: &Outgoing{
+								IP:   pod.Status.PodIP,
+								Port: cPathPair.Port,
+							},
+						})
+					}
+				}
 			}
+		} else {
+			log.Printf("    Pod (%s) is not routable: Missing '%s' annotation\n", pod.Name, KeyTrafficHostsA)
 		}
+	} else {
+		log.Printf("    Pod (%s) is not routable: Not running (%s)\n", pod.Name, pod.Status.Phase)
 	}
 
-	return routable
+	return routes
 }
 
 /*
 UpdatePodCacheForEvents updates the cache based on the pod events and returns if the changes warrant an nginx restart.
 */
-func UpdatePodCacheForEvents(cache map[string]api.Pod, events []watch.Event) bool {
+func UpdatePodCacheForEvents(cache map[string]*PodWithRoutes, events []watch.Event) bool {
 	needsRestart := false
 
 	for _, event := range events {
 		// Coerce the event target to a Pod
 		pod := event.Object.(*api.Pod)
 
-		// Quick return if the pod is not routable
-		if !IsPodRoutable(*pod) {
-			needsRestart = true
-			delete(cache, pod.Name)
-			continue
-		}
+		log.Printf("  Pod (%s) event: %s\n", pod.Name, event.Type)
 
 		// Process the event
 		switch event.Type {
 		case watch.Added:
-			log.Printf("  Pod added: %s", pod.Name)
-
+			// This event is likely never going to be handled in the real world because most pod add events happen prior to
+			// pod being routable but it's here just in case.
 			needsRestart = true
-			cache[pod.Name] = *pod
+			cache[pod.Name] = &PodWithRoutes{
+				Pod:    pod,
+				Routes: GetRoutes(pod),
+			}
 
 		case watch.Deleted:
-			log.Printf("  Pod deleted: %s", pod.Name)
-
 			needsRestart = true
 			delete(cache, pod.Name)
 
 		case watch.Modified:
-			log.Printf("  Pod updated: %s", pod.Name)
-
 			// Check if the pod still has the microservice label
 			if val, ok := pod.ObjectMeta.Labels[KeyMicroserviceL]; ok {
 				if val != "true" {
-					log.Print("    Pod is no longer a microservice")
+					log.Println("    Pod is no longer a microservice")
 
 					// Pod no longer the `microservices` label set to true
 					// so we need to remove it from the cache
 					needsRestart = true
 					delete(cache, pod.Name)
 				} else {
-					// If the annotations we're interested in change, rebuild
-					if pod.Annotations[KeyMicroserviceL] != cache[pod.Name].Annotations[KeyMicroserviceL] ||
-						pod.Annotations[KeyTrafficHostsA] != cache[pod.Name].Annotations[KeyTrafficHostsA] ||
-						pod.Annotations[KeyPublicPathsA] != cache[pod.Name].Annotations[KeyPublicPathsA] ||
-						pod.Annotations[KeyPathPortA] != cache[pod.Name].Annotations[KeyPathPortA] {
+					cached, ok := cache[pod.Name]
+
+					// If the annotations we're interested in change or if there is no cache entry, rebuild
+					if !ok ||
+						pod.Annotations[KeyMicroserviceL] != cached.Pod.Annotations[KeyMicroserviceL] ||
+						pod.Annotations[KeyTrafficHostsA] != cached.Pod.Annotations[KeyTrafficHostsA] ||
+						pod.Annotations[KeyPublicPathsA] != cached.Pod.Annotations[KeyPublicPathsA] {
 						needsRestart = true
 					}
 
 					// Add/Update the cache entry
-					cache[pod.Name] = *pod
+					cache[pod.Name].Pod = pod
+					cache[pod.Name].Routes = GetRoutes(pod)
 				}
 			} else {
-				log.Print("    Pod is no longer a microservice")
+				log.Println("    Pod is no longer a microservice")
 
 				// Pod no longer has the `microservices` label so we need to
 				// remove it from the cache
 				needsRestart = true
 				delete(cache, pod.Name)
+			}
+		}
+
+		cacheEntry, ok := cache[pod.Name]
+
+		if ok {
+			if len(cacheEntry.Routes) > 0 {
+				log.Println("    Pod is routable")
+			} else {
+				log.Println("    Pod is not routable")
 			}
 		}
 	}

--- a/ingress/pods_test.go
+++ b/ingress/pods_test.go
@@ -15,6 +15,48 @@ func init() {
 	log.SetOutput(ioutil.Discard)
 }
 
+func validateRoutes(t *testing.T, desc string, expected, actual []*Route) {
+	aCount := 0
+	eCount := 0
+
+	if actual != nil {
+		aCount = len(actual)
+	}
+
+	if expected != nil {
+		eCount = len(expected)
+	}
+
+	// First check that we have the proper number of routes
+	if aCount != eCount {
+		t.Fatalf("Expected %d routes but found %d routes: %s\n", eCount, aCount, desc)
+	}
+
+	// Validate each route positionally
+	find := func(items []*Route, item *Route) *Route {
+		var route *Route
+
+		for _, cRoute := range items {
+			if item.Incoming.Host == cRoute.Incoming.Host &&
+				item.Incoming.Path == cRoute.Incoming.Path &&
+				item.Outgoing.IP == cRoute.Outgoing.IP &&
+				item.Outgoing.Port == cRoute.Outgoing.Port {
+				route = cRoute
+
+				break
+			}
+		}
+
+		return route
+	}
+
+	for _, route := range expected {
+		if find(actual, route) == nil {
+			t.Fatalf("Unable to find route (%s): %s\n", route, desc)
+		}
+	}
+}
+
 /*
 Test for github.com/30x/k8s-pods-ingress/ingress/pods#GetMicroservicePodList
 */
@@ -45,85 +87,266 @@ func TestGetMicroservicePodList(t *testing.T) {
 }
 
 /*
-Test for github.com/30x/k8s-pods-ingress/ingress/pods#IsPodRoutable where pod has an invalid pathPort annotation
+Test for github.com/30x/k8s-pods-ingress/ingress/pods#GetRoutes where the pod is not running
 */
-func TestIsPodRoutableInvalidPathPort(t *testing.T) {
-	if IsPodRoutable(api.Pod{
-		ObjectMeta: api.ObjectMeta{
-			Annotations: map[string]string{
-				"trafficHosts": "test.github.com",
-				"pathPort":     "invalid",
-			},
-		},
-		Status: api.PodStatus{
-			Phase: api.PodRunning,
-		},
-	}) {
-		t.Fatal("Pod has an invalid pathPort annotation so it is not routable")
-	}
-}
-
-/*
-Test for github.com/30x/k8s-pods-ingress/ingress/pods#IsPodRoutable where pod has no trafficHosts annotation
-*/
-func TestIsPodRoutableNoTrafficHosts(t *testing.T) {
-	if IsPodRoutable(api.Pod{
-		Status: api.PodStatus{
-			Phase: api.PodRunning,
-		},
-	}) {
-		t.Fatal("Pod has no trafficHosts annotation so it is not routable")
-	}
-}
-
-/*
-Test for github.com/30x/k8s-pods-ingress/ingress/pods#IsPodRoutable where pod has an invalid trafficHosts annotation
-*/
-func TestIsPodRoutableInvalidTrafficHosts(t *testing.T) {
-	if IsPodRoutable(api.Pod{
-		ObjectMeta: api.ObjectMeta{
-			Annotations: map[string]string{
-				"trafficHosts": "test.github.com test.",
-				"pathPort":     "invalid",
-			},
-		},
-		Status: api.PodStatus{
-			Phase: api.PodRunning,
-		},
-	}) {
-		t.Fatal("Pod has an invalid trafficHosts annotation so it is not routable")
-	}
-}
-
-/*
-Test for github.com/30x/k8s-pods-ingress/ingress/pods#IsPodRoutable where pod is not running
-*/
-func TestIsPodRoutableNotRunning(t *testing.T) {
-	if IsPodRoutable(api.Pod{
+func TestGetRoutesNotRunning(t *testing.T) {
+	validateRoutes(t, "pod not running", []*Route{}, GetRoutes(&api.Pod{
 		Status: api.PodStatus{
 			Phase: api.PodPending,
 		},
-	}) {
-		t.Fatal("Pod is not running so it is not routable")
-	}
+	}))
 }
 
 /*
-Test for github.com/30x/k8s-pods-ingress/ingress/pods#IsPodRoutable where pod is valid and should be routable
+Test for github.com/30x/k8s-pods-ingress/ingress/pods#GetRoutes where the pod has no trafficHosts annotation
 */
-func TestIsPodRoutableValidPod(t *testing.T) {
-	if !IsPodRoutable(api.Pod{
+func TestGetRoutesNoTrafficHosts(t *testing.T) {
+	validateRoutes(t, "pod has no trafficHosts annotation", []*Route{}, GetRoutes(&api.Pod{
+		Status: api.PodStatus{
+			Phase: api.PodRunning,
+		},
+	}))
+}
+
+/*
+Test for github.com/30x/k8s-pods-ingress/ingress/pods#GetRoutes where the pod has an invalid trafficHosts annotation
+*/
+func TestGetRoutesInvalidTrafficHosts(t *testing.T) {
+	validateRoutes(t, "pod has an invalid trafficHosts host", []*Route{}, GetRoutes(&api.Pod{
 		ObjectMeta: api.ObjectMeta{
 			Annotations: map[string]string{
-				"trafficHosts": "test.github.com",
+				"trafficHosts": "test.github.com test.",
 			},
 		},
 		Status: api.PodStatus{
 			Phase: api.PodRunning,
 		},
-	}) {
-		t.Fatal("Pod is valid and should be routable")
-	}
+	}))
+}
+
+/*
+Test for github.com/30x/k8s-pods-ingress/ingress/pods#GetRoutes where the pod has an invalid port value in the publicPaths annotation
+*/
+func TestGetRoutesInvalidPublicPathsPort(t *testing.T) {
+	// Not a valid integer
+	validateRoutes(t, "pod has an invalid publicPaths port (invalid integer)", []*Route{}, GetRoutes(&api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			Annotations: map[string]string{
+				"trafficHosts": "test.github.com",
+				"publicPaths":  "abcdef:/",
+			},
+		},
+		Status: api.PodStatus{
+			Phase: api.PodRunning,
+		},
+	}))
+
+	// Port is less than 0
+	validateRoutes(t, "pod has an invalid publicPaths port (port < 0)", []*Route{}, GetRoutes(&api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			Annotations: map[string]string{
+				"trafficHosts": "test.github.com",
+				"publicPaths":  "-1:/",
+			},
+		},
+		Status: api.PodStatus{
+			Phase: api.PodRunning,
+		},
+	}))
+
+	// Port is greater than 65535
+	validateRoutes(t, "pod has an invalid publicPaths port (port > 65536)", []*Route{}, GetRoutes(&api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			Annotations: map[string]string{
+				"trafficHosts": "test.github.com",
+				"publicPaths":  "77777:/",
+			},
+		},
+		Status: api.PodStatus{
+			Phase: api.PodRunning,
+		},
+	}))
+}
+
+/*
+Test for github.com/30x/k8s-pods-ingress/ingress/pods#GetRoutes where the pod has an invalid path value in the publicPaths annotation
+*/
+func TestGetRoutesInvalidPublicPathsPath(t *testing.T) {
+	// "%ZZ" is not a valid path segment
+	validateRoutes(t, "pod has an invalid publicPaths path", []*Route{}, GetRoutes(&api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			Annotations: map[string]string{
+				"trafficHosts": "test.github.com",
+				"publicPaths":  "3000:/people/%ZZ",
+			},
+		},
+		Status: api.PodStatus{
+			Phase: api.PodRunning,
+		},
+	}))
+}
+
+/*
+Test for github.com/30x/k8s-pods-ingress/ingress/pods#GetRoutes where the pod has no publicPaths annotation
+*/
+func TestGetRoutesValidPods(t *testing.T) {
+	host1 := "test.github.com"
+	host2 := "www.github.com"
+	ip := "10.244.1.17"
+	path1 := "/"
+	path2 := "/admin"
+	port1 := "3000"
+	port2 := "3001"
+
+	// A single host and path
+	validateRoutes(t, "single host and path", []*Route{
+		&Route{
+			Incoming: &Incoming{
+				Host: host1,
+				Path: path1,
+			},
+			Outgoing: &Outgoing{
+				IP:   ip,
+				Port: port1,
+			},
+		},
+	}, GetRoutes(&api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			Annotations: map[string]string{
+				"trafficHosts": host1,
+				"publicPaths":  port1 + ":" + path1,
+			},
+		},
+		Status: api.PodStatus{
+			Phase: api.PodRunning,
+			PodIP: ip,
+		},
+	}))
+
+	// A single host and multiple paths
+	validateRoutes(t, "single host and multiple paths", []*Route{
+		&Route{
+			Incoming: &Incoming{
+				Host: host1,
+				Path: path1,
+			},
+			Outgoing: &Outgoing{
+				IP:   ip,
+				Port: port1,
+			},
+		},
+		&Route{
+			Incoming: &Incoming{
+				Host: host1,
+				Path: path2,
+			},
+			Outgoing: &Outgoing{
+				IP:   ip,
+				Port: port2,
+			},
+		},
+	}, GetRoutes(&api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			Annotations: map[string]string{
+				"trafficHosts": host1,
+				"publicPaths":  port1 + ":" + path1 + " " + port2 + ":" + path2,
+			},
+		},
+		Status: api.PodStatus{
+			Phase: api.PodRunning,
+			PodIP: ip,
+		},
+	}))
+
+	// Multiple hosts and single path
+	validateRoutes(t, "multiple hosts and single path", []*Route{
+		&Route{
+			Incoming: &Incoming{
+				Host: host1,
+				Path: path1,
+			},
+			Outgoing: &Outgoing{
+				IP:   ip,
+				Port: port1,
+			},
+		},
+		&Route{
+			Incoming: &Incoming{
+				Host: host2,
+				Path: path1,
+			},
+			Outgoing: &Outgoing{
+				IP:   ip,
+				Port: port1,
+			},
+		},
+	}, GetRoutes(&api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			Annotations: map[string]string{
+				"trafficHosts": host1 + " " + host2,
+				"publicPaths":  port1 + ":" + path1,
+			},
+		},
+		Status: api.PodStatus{
+			Phase: api.PodRunning,
+			PodIP: ip,
+		},
+	}))
+
+	// Multiple hosts and multiple paths
+	validateRoutes(t, "multiple hosts and multiple paths", []*Route{
+		&Route{
+			Incoming: &Incoming{
+				Host: host1,
+				Path: path1,
+			},
+			Outgoing: &Outgoing{
+				IP:   ip,
+				Port: port1,
+			},
+		},
+		&Route{
+			Incoming: &Incoming{
+				Host: host1,
+				Path: path2,
+			},
+			Outgoing: &Outgoing{
+				IP:   ip,
+				Port: port2,
+			},
+		},
+		&Route{
+			Incoming: &Incoming{
+				Host: host2,
+				Path: path1,
+			},
+			Outgoing: &Outgoing{
+				IP:   ip,
+				Port: port1,
+			},
+		},
+		&Route{
+			Incoming: &Incoming{
+				Host: host2,
+				Path: path2,
+			},
+			Outgoing: &Outgoing{
+				IP:   ip,
+				Port: port2,
+			},
+		},
+	}, GetRoutes(&api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			Annotations: map[string]string{
+				"trafficHosts": host1 + " " + host2,
+				"publicPaths":  port1 + ":" + path1 + " " + port2 + ":" + path2,
+			},
+		},
+		Status: api.PodStatus{
+			Phase: api.PodRunning,
+			PodIP: ip,
+		},
+	}))
 }
 
 /*
@@ -132,11 +355,12 @@ Test for github.com/30x/k8s-pods-ingress/ingress/pods#UpdatePodCacheForEvents
 func TestUpdatePodCacheForEvents(t *testing.T) {
 	annotations := map[string]string{
 		"trafficHosts": "test.github.com",
+		"publicPaths":  "80:/",
 	}
 	labels := map[string]string{
 		"microservice": "true",
 	}
-	addedPod := api.Pod{
+	addedPod := &api.Pod{
 		ObjectMeta: api.ObjectMeta{
 			Name:        "added",
 			Annotations: annotations,
@@ -147,7 +371,7 @@ func TestUpdatePodCacheForEvents(t *testing.T) {
 			PodIP: "10.244.1.17",
 		},
 	}
-	deletedPod := api.Pod{
+	deletedPod := &api.Pod{
 		ObjectMeta: api.ObjectMeta{
 			Name:        "deleted",
 			Annotations: annotations,
@@ -158,7 +382,7 @@ func TestUpdatePodCacheForEvents(t *testing.T) {
 			PodIP: "10.244.1.18",
 		},
 	}
-	modifiedPod1 := api.Pod{
+	modifiedPod1 := &api.Pod{
 		ObjectMeta: api.ObjectMeta{
 			Name:        "modifiedPod1",
 			Annotations: annotations,
@@ -169,7 +393,7 @@ func TestUpdatePodCacheForEvents(t *testing.T) {
 			PodIP: "10.244.1.19",
 		},
 	}
-	modifiedPod2 := api.Pod{
+	modifiedPod2 := &api.Pod{
 		ObjectMeta: api.ObjectMeta{
 			Name:        "modifiedPod2",
 			Annotations: annotations,
@@ -180,7 +404,7 @@ func TestUpdatePodCacheForEvents(t *testing.T) {
 			PodIP: "10.244.1.20",
 		},
 	}
-	modifiedPod3 := api.Pod{
+	modifiedPod3 := &api.Pod{
 		ObjectMeta: api.ObjectMeta{
 			Name:        "modifiedPod3",
 			Annotations: annotations,
@@ -191,7 +415,7 @@ func TestUpdatePodCacheForEvents(t *testing.T) {
 			PodIP: "10.244.1.21",
 		},
 	}
-	unroutablePod := api.Pod{
+	unroutablePod := &api.Pod{
 		ObjectMeta: api.ObjectMeta{
 			Name:   "unroutable",
 			Labels: labels,
@@ -200,27 +424,39 @@ func TestUpdatePodCacheForEvents(t *testing.T) {
 			Phase: api.PodPending,
 		},
 	}
-	cache := map[string]api.Pod{
-		"deleted":      deletedPod,
-		"modifiedPod1": modifiedPod1,
-		"modifiedPod2": modifiedPod2,
-		"modifiedPod3": modifiedPod3,
+	cache := map[string]*PodWithRoutes{
+		"deleted": &PodWithRoutes{
+			Pod:    deletedPod,
+			Routes: GetRoutes(deletedPod),
+		},
+		"modifiedPod1": &PodWithRoutes{
+			Pod:    modifiedPod1,
+			Routes: GetRoutes(modifiedPod1),
+		},
+		"modifiedPod2": &PodWithRoutes{
+			Pod:    modifiedPod2,
+			Routes: GetRoutes(modifiedPod2),
+		},
+		"modifiedPod3": &PodWithRoutes{
+			Pod:    modifiedPod3,
+			Routes: GetRoutes(modifiedPod3),
+		},
 	}
 	events := []watch.Event{
 		// Added but unroutable so it should not be in the cache
 		watch.Event{
 			Type:   watch.Added,
-			Object: &unroutablePod,
+			Object: unroutablePod,
 		},
 		// Added and routable so it should be in the cache
 		watch.Event{
 			Type:   watch.Added,
-			Object: &addedPod,
+			Object: addedPod,
 		},
 		// Deleted and should be removed fromt he cache
 		watch.Event{
 			Type:   watch.Deleted,
-			Object: &deletedPod,
+			Object: deletedPod,
 		},
 		// Modified and missing the microservice label so it should not be in the cache
 		watch.Event{
@@ -261,7 +497,7 @@ func TestUpdatePodCacheForEvents(t *testing.T) {
 					Name: "modifiedPod3",
 					Annotations: map[string]string{
 						"trafficHosts": "prod.github.com",
-						"publicPaths":  "/v1/api",
+						"publicPaths":  "80:/v1/api",
 					},
 					Labels: labels,
 				},
@@ -289,7 +525,7 @@ func TestUpdatePodCacheForEvents(t *testing.T) {
 		}
 	}
 
-	if _, ok := cache["modifiedPod3"].Annotations["publicPaths"]; !ok {
+	if _, ok := cache["modifiedPod3"].Pod.Annotations["publicPaths"]; !ok {
 		t.Fatalf("The \"modifiedPod3\" \"publicPaths\" annotation should had been updated")
 	}
 }


### PR DESCRIPTION
This commit removes support for the `pathPort` annotation and instead
uses the `publicPaths` annotation to provide all of the details
necessary to map a request path to a particular container within a pod.
This will allow you to expose path routing for multiple containers
within the same application using a simple convention: `{CONTAINER_PORT}:{PATH}`

See: #11
Subtask Link: https://github.com/30x/k8s-pods-ingress/issues/11#issuecomment-208422348