### PR TITLE
First pass at API Key authorization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all: build
 check: test lint
 
 clean:
-	rm -f k8s-pods-ingress ingress/ingress.test kubernetes/kubernetes.test nginx/nginx.test
+	rm -f coverage.out k8s-pods-ingress ingress/ingress.test kubernetes/kubernetes.test nginx/nginx.test
 
 lint:
 	golint ingress

--- a/ingress/secrets.go
+++ b/ingress/secrets.go
@@ -1,0 +1,109 @@
+package ingress
+
+import (
+	"log"
+
+	"k8s.io/kubernetes/pkg/api"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+const (
+	// KeyIngressSecretName is the name of the secret to identify as an ingress secret
+	KeyIngressSecretName = "ingress"
+	// KeyIngressAPIKey is the name of the secret data to use as the API Key
+	KeyIngressAPIKey = "api-key"
+)
+
+/*
+GetIngressSecretList returns the ingress secrets.
+*/
+func GetIngressSecretList(kubeClient *client.Client) (*api.SecretList, error) {
+	// Query all secrets
+	secretList, err := kubeClient.Secrets(api.NamespaceAll).List(api.ListOptions{})
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Filter out the secrets that are not ingress API Key secrets or that do not have the proper secret key
+	var filtered []api.Secret
+
+	for _, secret := range secretList.Items {
+		if secret.Name == KeyIngressSecretName {
+			_, ok := secret.Data[KeyIngressAPIKey]
+
+			if ok {
+				filtered = append(filtered, secret)
+			} else {
+				log.Printf("    Ingress secret for namespace (%s) is not usable: Missing '%s' key\n", secret.Namespace, KeyIngressAPIKey)
+			}
+		}
+	}
+
+	secretList.Items = filtered
+
+	return secretList, nil
+}
+
+/*
+UpdateSecretCacheForEvents updates the cache based on the secret events and returns if the changes warrant an nginx restart.
+*/
+func UpdateSecretCacheForEvents(cache map[string]*api.Secret, events []watch.Event) bool {
+	needsRestart := false
+
+	for _, event := range events {
+		// Coerce the event target to a Secret
+		secret := event.Object.(*api.Secret)
+		namespace := secret.Namespace
+
+		log.Printf("  Secret (%s in %s namespace) event: %s\n", secret.Name, secret.Namespace, event.Type)
+
+		// Process the event
+		switch event.Type {
+		case watch.Added:
+			cache[namespace] = secret
+			needsRestart = true
+
+		case watch.Deleted:
+			delete(cache, namespace)
+			needsRestart = true
+
+		case watch.Modified:
+			cached, ok := cache[namespace]
+			apiKey, _ := secret.Data[KeyIngressAPIKey]
+
+			if ok {
+				cachedAPIKey, _ := cached.Data[KeyIngressAPIKey]
+
+				if (apiKey == nil && cachedAPIKey != nil) || (apiKey != nil && cachedAPIKey == nil) {
+					needsRestart = true
+				} else if apiKey != nil && cachedAPIKey != nil && len(apiKey) != len(cachedAPIKey) {
+					needsRestart = true
+				} else {
+					for i := range apiKey {
+						if apiKey[i] != cachedAPIKey[i] {
+							needsRestart = true
+
+							break
+						}
+					}
+				}
+			}
+
+			cache[namespace] = secret
+		}
+
+		if _, ok := cache[namespace]; ok {
+			apiKey, _ := secret.Data[KeyIngressAPIKey]
+
+			if apiKey == nil {
+				log.Printf("    Secret has an %s value: no\n", KeyIngressAPIKey)
+			} else {
+				log.Printf("    Secret has an %s value: yes\n", KeyIngressAPIKey)
+			}
+		}
+	}
+
+	return needsRestart
+}

--- a/ingress/secrets_test.go
+++ b/ingress/secrets_test.go
@@ -1,0 +1,134 @@
+package ingress
+
+import (
+	"io/ioutil"
+	"log"
+	"testing"
+
+	"github.com/30x/k8s-pods-ingress/kubernetes"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+func init() {
+	log.SetOutput(ioutil.Discard)
+}
+
+/*
+Test for github.com/30x/k8s-pods-ingress/ingress/secrets#GetIngressSecretList
+*/
+func TestGetIngressSecretList(t *testing.T) {
+	kubeClient, err := kubernetes.GetClient()
+
+	if err != nil {
+		t.Fatalf("Failed to create k8s client: %v.", err)
+	}
+
+	secretList, err := GetIngressSecretList(kubeClient)
+
+	if err != nil {
+		t.Fatalf("Failed to get the ingress secrets: %v.", err)
+	}
+
+	for _, secret := range secretList.Items {
+		if secret.Name != KeyIngressSecretName {
+			t.Fatalf("Every secret should have a %s name", KeyIngressSecretName)
+		}
+	}
+}
+
+/*
+Test for github.com/30x/k8s-pods-ingress/ingress/secrets#UpdateSecretCacheForEvents
+*/
+func TestUpdateSecretCacheForEvents(t *testing.T) {
+	apiKeyStr := "API-Key"
+	apiKey := []byte(apiKeyStr)
+	cache := make(map[string]*api.Secret)
+	namespace := "my-namespace"
+
+	addedSecret := &api.Secret{
+		ObjectMeta: api.ObjectMeta{
+			Name:      KeyIngressSecretName,
+			Namespace: "my-namespace",
+		},
+		Data: map[string][]byte{
+			"api-key": apiKey,
+		},
+	}
+	modifiedSecretNoRestart := &api.Secret{
+		ObjectMeta: api.ObjectMeta{
+			Name:      KeyIngressSecretName,
+			Namespace: "my-namespace",
+		},
+		Data: map[string][]byte{
+			"api-key": apiKey,
+			"new-key": []byte("New-API-Key"),
+		},
+	}
+	modifiedSecretRestart := &api.Secret{
+		ObjectMeta: api.ObjectMeta{
+			Name:      KeyIngressSecretName,
+			Namespace: "my-namespace",
+		},
+		Data: map[string][]byte{
+			"api-key": []byte("Updated-API-Key"),
+		},
+	}
+
+	// Test add event
+	needsRestart := UpdateSecretCacheForEvents(cache, []watch.Event{
+		watch.Event{
+			Type:   watch.Added,
+			Object: addedSecret,
+		},
+	})
+
+	if !needsRestart {
+		t.Fatal("Server should require a restart")
+	} else if _, ok := cache[namespace]; !ok {
+		t.Fatal("Cache should reflect the added secret")
+	}
+
+	// Test modify event with unchanged api-key
+	needsRestart = UpdateSecretCacheForEvents(cache, []watch.Event{
+		watch.Event{
+			Type:   watch.Modified,
+			Object: modifiedSecretNoRestart,
+		},
+	})
+
+	if needsRestart {
+		t.Fatal("Server should not require a restart")
+	}
+
+	// Test modify event with changed api-key
+	needsRestart = UpdateSecretCacheForEvents(cache, []watch.Event{
+		watch.Event{
+			Type:   watch.Modified,
+			Object: modifiedSecretRestart,
+		},
+	})
+
+	if !needsRestart {
+		t.Fatal("Server should require a restart")
+	}
+
+	if apiKeyStr == string(cache[namespace].Data[KeyIngressAPIKey][:]) {
+		t.Fatal("Cache should have the updated secret")
+	}
+
+	// Test delete event
+	needsRestart = UpdateSecretCacheForEvents(cache, []watch.Event{
+		watch.Event{
+			Type:   watch.Deleted,
+			Object: addedSecret,
+		},
+	})
+
+	if !needsRestart {
+		t.Fatal("Server should require a restart")
+	} else if _, ok := cache[namespace]; ok {
+		t.Fatal("Cache should not have the deleted secret")
+	}
+}

--- a/ingress/types.go
+++ b/ingress/types.go
@@ -1,0 +1,45 @@
+package ingress
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+)
+
+/*
+Cache is the structure containing the ingress API Keys and the microservices pods cache
+*/
+type Cache struct {
+	Pods    map[string]*PodWithRoutes
+	Secrets map[string]*api.Secret
+}
+
+/*
+Incoming describes the information required to route an incoming request
+*/
+type Incoming struct {
+	Host string
+	Path string
+}
+
+/*
+Outgoing describes the information required to proxy to a backend
+*/
+type Outgoing struct {
+	IP   string
+	Port string
+}
+
+/*
+PodWithRoutes contains a pod and its routes
+*/
+type PodWithRoutes struct {
+	Pod    *api.Pod
+	Routes []*Route
+}
+
+/*
+Route describes the incoming route matching details and the outgoing proxy backend details
+*/
+type Route struct {
+	Incoming *Incoming
+	Outgoing *Outgoing
+}

--- a/nginx/config_test.go
+++ b/nginx/config_test.go
@@ -1,6 +1,7 @@
 package nginx
 
 import (
+	"encoding/base64"
 	"testing"
 
 	"github.com/30x/k8s-pods-ingress/ingress"
@@ -8,26 +9,35 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 )
 
-func validateConf(t *testing.T, desc, expected string, pods []*api.Pod) {
-	cache := make(map[string]*ingress.PodWithRoutes)
+func validateConf(t *testing.T, desc, expected string, pods []*api.Pod, secrets []*api.Secret) {
+	cache := &ingress.Cache{
+		Pods:    make(map[string]*ingress.PodWithRoutes),
+		Secrets: make(map[string]*api.Secret),
+	}
 
 	for _, pod := range pods {
-		cache[pod.Name] = &ingress.PodWithRoutes{
+		cache.Pods[pod.Name] = &ingress.PodWithRoutes{
 			Pod:    pod,
 			Routes: ingress.GetRoutes(pod),
 		}
 	}
 
-	if expected != GetConfForPods(cache) {
-		t.Fatal("Unexpected nginx.conf was generated (" + desc + ")")
+	for _, secret := range secrets {
+		cache.Secrets[secret.Namespace] = secret
+	}
+
+	actual := GetConf(cache)
+
+	if expected != actual {
+		t.Fatalf("Unexpected nginx.conf was generated (%s)\nExpected: %s\n\nActual: %s\n", desc, expected, actual)
 	}
 }
 
 /*
-Test for github.com/30x/k8s-pods-ingress/nginx/config#GetConfForPods with an empty cache
+Test for github.com/30x/k8s-pods-ingress/nginx/config#GetConf with an empty cache
 */
-func TestGetConfForPodsNoMicroservices(t *testing.T) {
-	conf := GetConfForPods(map[string]*ingress.PodWithRoutes{})
+func TestGetConfNoMicroservices(t *testing.T) {
+	conf := GetConf(&ingress.Cache{})
 
 	if conf != DefaultNginxConf {
 		t.Fatal("The default nginx.conf should be returned for an empty cache")
@@ -35,9 +45,9 @@ func TestGetConfForPodsNoMicroservices(t *testing.T) {
 }
 
 /*
-Test for github.com/30x/k8s-pods-ingress/nginx/config#GetConfForPods with single pod and multiple paths
+Test for github.com/30x/k8s-pods-ingress/nginx/config#GetConf with single pod and multiple paths
 */
-func TestGetConfForPodsMultiplePaths(t *testing.T) {
+func TestGetConfMultiplePaths(t *testing.T) {
 	expectedConf := `
 events {
   worker_connections 1024;
@@ -81,13 +91,13 @@ http {
 		},
 	}
 
-	validateConf(t, "single pod multiple paths", expectedConf, []*api.Pod{&pod})
+	validateConf(t, "single pod multiple paths", expectedConf, []*api.Pod{&pod}, []*api.Secret{})
 }
 
 /*
-Test for github.com/30x/k8s-pods-ingress/nginx/config#GetConfForPods with multiple, single pod services
+Test for github.com/30x/k8s-pods-ingress/nginx/config#GetConf with multiple, single pod services
 */
-func TestGetConfForPodsMultipleMicroservices(t *testing.T) {
+func TestGetConfMultipleMicroservices(t *testing.T) {
 	expectedConf := `
 events {
   worker_connections 1024;
@@ -151,13 +161,13 @@ http {
 		},
 	}
 
-	validateConf(t, "multiple pods, different services", expectedConf, pods)
+	validateConf(t, "multiple pods, different services", expectedConf, pods, []*api.Secret{})
 }
 
 /*
-Test for github.com/30x/k8s-pods-ingress/nginx/config#GetConfForPods with single, multiple pod services
+Test for github.com/30x/k8s-pods-ingress/nginx/config#GetConf with single, multiple pod services
 */
-func TestGetConfForPodsMultiplePodMicroservice(t *testing.T) {
+func TestGetConfMultiplePodMicroservice(t *testing.T) {
 	expectedConf := `
 events {
   worker_connections 1024;
@@ -233,5 +243,64 @@ http {
 		},
 	}
 
-	validateConf(t, "multiple pods, same service", expectedConf, pods)
+	validateConf(t, "multiple pods, same service", expectedConf, pods, []*api.Secret{})
+}
+
+/*
+Test for github.com/30x/k8s-pods-ingress/nginx/config#GetConf with single pod and multiple paths
+*/
+func TestGetConfWithAPIKey(t *testing.T) {
+	apiKey := []byte("Updated-API-Key")
+	expectedConf := `
+events {
+  worker_connections 1024;
+}
+http {
+  # http://nginx.org/en/docs/http/ngx_http_core_module.html
+  types_hash_max_size 2048;
+  server_names_hash_max_size 512;
+  server_names_hash_bucket_size 64;
+
+  server {
+    listen 80;
+    server_name test.github.com;
+
+    location / {
+      proxy_set_header Host $host;
+      # Check the Ingress API Key (namespace: testing)
+      if ($http_x_ingress_api_key != '` + base64.StdEncoding.EncodeToString(apiKey) + `') {
+        return 403;
+      }
+      # Pod testing
+      proxy_pass http://10.244.1.16;
+    }
+  }
+` + DefaultNginxServerConf + `}
+`
+
+	pod := api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			Annotations: map[string]string{
+				"trafficHosts": "test.github.com",
+				"publicPaths":  "80:/",
+			},
+			Name:      "testing",
+			Namespace: "testing",
+		},
+		Status: api.PodStatus{
+			Phase: api.PodRunning,
+			PodIP: "10.244.1.16",
+		},
+	}
+	secret := api.Secret{
+		ObjectMeta: api.ObjectMeta{
+			Name:      ingress.KeyIngressSecretName,
+			Namespace: "testing",
+		},
+		Data: map[string][]byte{
+			"api-key": apiKey,
+		},
+	}
+
+	validateConf(t, "pod with API Key", expectedConf, []*api.Pod{&pod}, []*api.Secret{&secret})
 }


### PR DESCRIPTION
This commit allows you to create a specially named secret in a namespace
and allow that secret to be used to authorize requests prior to routing.
To use this, create a generic secret named `ingress` with an `api-key`
data field.  Once you've done this, host and path combinations served by
pods in your namespace will check the value of the `X-INGRESS-API-KEY`
against the value in the secret and return a 403 if they do not match.

See: #11
Subtask Link: https://github.com/30x/k8s-pods-ingress/issues/11#issuecomment-209014852