### PR TITLE
Make the router's touch points configurable

### DIFF
--- a/demo/rc.yaml
+++ b/demo/rc.yaml
@@ -12,10 +12,10 @@ spec:
     metadata:
       labels:
         name: nodejs-k8s-env
-        microservice: "true"
+        routable: "true"
       annotations:
-        trafficHosts: "test.k8s.local"
-        publicPaths: "3000:/nodejs"
+        routingHosts: "test.k8s.local"
+        routingPaths: "3000:/nodejs"
     spec:
       containers:
       - name: nodejs-k8s-env

--- a/ingress/config.go
+++ b/ingress/config.go
@@ -1,0 +1,99 @@
+package ingress
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/util/validation"
+)
+
+const (
+	// DefaultAPIKeySecret is the default value for the first portion of the DefaultAPIKeySecretLocation (routing)
+	DefaultAPIKeySecret = "routing"
+	// DefaultAPIKeySecretDataField is the default value for the second portion of the DefaultAPIKeySecretDataField (api-key)
+	DefaultAPIKeySecretDataField = "api-key"
+	// DefaultAPIKeySecretLocation is the default value for the EnvVarAPIKeySecretLocation (routing:api-key)
+	DefaultAPIKeySecretLocation = DefaultAPIKeySecret + ":" + DefaultAPIKeySecretDataField
+	// DefaultHostsAnnotation is the default value for EnvVarHostsAnnotation (routingHosts)
+	DefaultHostsAnnotation = "routingHosts"
+	// DefaultPathsAnnotation is the default value for the EnvVarHostsAnnotation (routingPaths)
+	DefaultPathsAnnotation = "routingPaths"
+	// DefaultRoutableLabelSelector is the default value for EnvVarRoutableLabelSelector (routable=true)
+	DefaultRoutableLabelSelector = "routable=true"
+	// EnvVarAPIKeySecretLocation Environment variable name for providing the location of the secret (name:field) to identify API Key secrets
+	EnvVarAPIKeySecretLocation = "API_KEY_SECRET_LOCATION"
+	// EnvVarHostsAnnotation Environment variable name for providing the name of the hosts annotation
+	EnvVarHostsAnnotation = "HOSTS_ANNOTATION"
+	// EnvVarPathsAnnotation Environment variable name for providing the the name of the paths annotation
+	EnvVarPathsAnnotation = "PATHS_ANNOTATION"
+	// EnvVarRoutableLabelSelector Environment variable name for providing the label selector for identifying routable objects
+	EnvVarRoutableLabelSelector = "ROUTABLE_LABEL_SELECTOR"
+	// ErrMsgTmplInvalidAnnotationName is the error message template for an invalid annotation name
+	ErrMsgTmplInvalidAnnotationName = "%s has an invalid annotation name: %s"
+	// ErrMsgTmplInvalidAPIKeySecretLocation is the error message template for invalid API Key Secret location environment variable values
+	ErrMsgTmplInvalidAPIKeySecretLocation = "%s is not in the format of {API_KEY_SECRET_NAME}:{API_KEY_SECRET_DATA_FIELD_NAME}"
+	// ErrMsgTmplInvalidLabelSelector is the error message template for an invalid label selector
+	ErrMsgTmplInvalidLabelSelector = "%s has an invalid label selector: %s\n"
+)
+
+/*
+ConfigFromEnv returns the configuration based on the environment variables and validates the values
+*/
+func ConfigFromEnv() (*Config, error) {
+	config := &Config{
+		HostsAnnotation: os.Getenv(EnvVarHostsAnnotation),
+		PathsAnnotation: os.Getenv(EnvVarPathsAnnotation),
+	}
+
+	// Apply defaults
+	if config.HostsAnnotation == "" {
+		config.HostsAnnotation = DefaultHostsAnnotation
+	}
+
+	if config.PathsAnnotation == "" {
+		config.PathsAnnotation = DefaultPathsAnnotation
+	}
+
+	// Validate configuration
+	apiKeySecretLocation := os.Getenv(EnvVarAPIKeySecretLocation)
+	var apiKeySecretLocationParts []string
+
+	if apiKeySecretLocation == "" {
+		// No need to validate, just use the default
+		config.APIKeySecret = DefaultAPIKeySecret
+		config.APIKeySecretDataField = DefaultAPIKeySecretDataField
+	} else {
+		apiKeySecretLocationParts = strings.Split(apiKeySecretLocation, ":")
+
+		if len(apiKeySecretLocationParts) == 2 {
+			config.APIKeySecret = apiKeySecretLocationParts[0]
+			config.APIKeySecretDataField = apiKeySecretLocationParts[1]
+		} else {
+			return nil, fmt.Errorf(ErrMsgTmplInvalidAPIKeySecretLocation, EnvVarAPIKeySecretLocation)
+		}
+	}
+
+	if !validation.IsQualifiedName(strings.ToLower(config.HostsAnnotation)) {
+		return nil, fmt.Errorf(ErrMsgTmplInvalidAnnotationName, EnvVarHostsAnnotation, config.HostsAnnotation)
+	} else if !validation.IsQualifiedName(strings.ToLower(config.PathsAnnotation)) {
+		return nil, fmt.Errorf(ErrMsgTmplInvalidAnnotationName, EnvVarPathsAnnotation, config.PathsAnnotation)
+	}
+
+	routableLabelSelector := os.Getenv(EnvVarRoutableLabelSelector)
+
+	if routableLabelSelector == "" {
+		routableLabelSelector = DefaultRoutableLabelSelector
+	}
+
+	selector, err := labels.Parse(routableLabelSelector)
+
+	if err == nil {
+		config.RoutableLabelSelector = selector
+	} else {
+		return nil, fmt.Errorf(ErrMsgTmplInvalidLabelSelector, EnvVarRoutableLabelSelector, routableLabelSelector)
+	}
+
+	return config, nil
+}

--- a/ingress/config_test.go
+++ b/ingress/config_test.go
@@ -1,0 +1,151 @@
+package ingress
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+func getConfig(t *testing.T) *Config {
+	config, err := ConfigFromEnv()
+
+	if err != nil {
+		t.Fatalf("Problem retrieving configuration")
+	}
+
+	return config
+}
+
+func getLabelSelector(t *testing.T, labelSelector string) labels.Selector {
+	selector, err := labels.Parse(labelSelector)
+
+	if err != nil {
+		t.Fatalf("Unable to parse the label selector (%s): %v\n", labelSelector, err)
+	}
+
+	return selector
+}
+
+func resetEnv(t *testing.T) {
+	unsetEnv := func(name string) {
+		err := os.Unsetenv(name)
+
+		if err != nil {
+			t.Fatalf("Unable to unset environment variable (%s): %v\n", name, err)
+		}
+	}
+
+	unsetEnv(EnvVarAPIKeySecretLocation)
+	unsetEnv(EnvVarHostsAnnotation)
+	unsetEnv(EnvVarPathsAnnotation)
+	unsetEnv(EnvVarRoutableLabelSelector)
+}
+
+func setEnv(t *testing.T, key, value string) {
+	err := os.Setenv(key, value)
+
+	if err != nil {
+		t.Fatalf("Unable to set environment variable (%s = %s): %v\n", key, value, err)
+	}
+}
+
+func validateConfig(t *testing.T, desc string, expected *Config, actual *Config) {
+	makeError := func(field, eValue, aValue string) string {
+		return fmt.Sprintf("Expected %s (%s) does not match actual %s (%s): %s\n", field, eValue, field, aValue, desc)
+	}
+
+	if expected.APIKeySecret != actual.APIKeySecret {
+		t.Fatalf(makeError("APIKeySecret", expected.APIKeySecret, actual.APIKeySecret))
+	} else if expected.APIKeySecretDataField != actual.APIKeySecretDataField {
+		t.Fatalf(makeError("APIKeySecretDataField", expected.APIKeySecretDataField, actual.APIKeySecretDataField))
+	} else if expected.HostsAnnotation != actual.HostsAnnotation {
+		t.Fatalf(makeError("HostsAnnotation", expected.HostsAnnotation, actual.HostsAnnotation))
+	} else if expected.PathsAnnotation != actual.PathsAnnotation {
+		t.Fatalf(makeError("PathsAnnotation", expected.PathsAnnotation, actual.PathsAnnotation))
+	} else if expected.RoutableLabelSelector.String() != actual.RoutableLabelSelector.String() {
+		t.Fatalf(makeError("RoutableLabelSelector", expected.RoutableLabelSelector.String(), actual.RoutableLabelSelector.String()))
+	}
+}
+
+/*
+Test for github.com/30x/k8s-pods-ingress/ingress/config#ConfigFromEnv using the default environment
+*/
+func TestConfigFromEnvDefaultConfig(t *testing.T) {
+	validateConfig(t, "default configuration", getConfig(t), &Config{
+		APIKeySecret:          DefaultAPIKeySecret,
+		APIKeySecretDataField: DefaultAPIKeySecretDataField,
+		HostsAnnotation:       DefaultHostsAnnotation,
+		PathsAnnotation:       DefaultPathsAnnotation,
+		RoutableLabelSelector: getLabelSelector(t, DefaultRoutableLabelSelector),
+	})
+}
+
+/*
+Test for github.com/30x/k8s-pods-ingress/ingress/config#ConfigFromEnv using invalid configurations
+*/
+func TestConfigFromEnvInvalidEnv(t *testing.T) {
+	validateInvalidConfig := func(errMsg string) {
+		config, err := ConfigFromEnv()
+
+		if config != nil {
+			t.Fatal("Config should be nil")
+		} else if errMsg != err.Error() {
+			t.Fatalf("Expected error message (%s) but found: %s\n", errMsg, err.Error())
+		}
+
+		resetEnv(t)
+	}
+
+	// Reset the environment variables just in case
+	resetEnv(t)
+
+	// Invalid API Key Secret location
+	setEnv(t, EnvVarAPIKeySecretLocation, "routing")
+
+	validateInvalidConfig(fmt.Sprintf(ErrMsgTmplInvalidAPIKeySecretLocation, EnvVarAPIKeySecretLocation))
+
+	// Invalid hosts annotation
+	invalidName := "*&^^%&%$$^&%&"
+
+	setEnv(t, EnvVarHostsAnnotation, invalidName)
+
+	validateInvalidConfig(fmt.Sprintf(ErrMsgTmplInvalidAnnotationName, EnvVarHostsAnnotation, invalidName))
+
+	// Invalid paths annotation
+	setEnv(t, EnvVarPathsAnnotation, invalidName)
+
+	validateInvalidConfig(fmt.Sprintf(ErrMsgTmplInvalidAnnotationName, EnvVarPathsAnnotation, invalidName))
+
+	// Invalid routable label selector
+	setEnv(t, EnvVarRoutableLabelSelector, invalidName)
+
+	validateInvalidConfig(fmt.Sprintf(ErrMsgTmplInvalidLabelSelector, EnvVarRoutableLabelSelector, invalidName))
+}
+
+/*
+Test for github.com/30x/k8s-pods-ingress/ingress/config#ConfigFromEnv using a valid environment
+*/
+func TestConfigFromEnvValidConfig(t *testing.T) {
+	resetEnv(t)
+
+	hostsAnnotation := "trafficHosts"
+	pathsAnnotation := "publicPaths"
+	routableLabelSelector := "route-me=true"
+	secretName := "custom"
+	secretDataField := "another-custom"
+
+	setEnv(t, EnvVarAPIKeySecretLocation, secretName+":"+secretDataField)
+	setEnv(t, EnvVarHostsAnnotation, hostsAnnotation)
+	setEnv(t, EnvVarPathsAnnotation, pathsAnnotation)
+	setEnv(t, EnvVarRoutableLabelSelector, routableLabelSelector)
+
+	validateConfig(t, "default configuration", getConfig(t), &Config{
+		APIKeySecret:          secretName,
+		APIKeySecretDataField: secretDataField,
+		HostsAnnotation:       hostsAnnotation,
+		PathsAnnotation:       pathsAnnotation,
+		RoutableLabelSelector: getLabelSelector(t, routableLabelSelector),
+	})
+}

--- a/ingress/secrets.go
+++ b/ingress/secrets.go
@@ -8,17 +8,10 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
-const (
-	// KeyIngressSecretName is the name of the secret to identify as an ingress secret
-	KeyIngressSecretName = "ingress"
-	// KeyIngressAPIKey is the name of the secret data to use as the API Key
-	KeyIngressAPIKey = "api-key"
-)
-
 /*
 GetIngressSecretList returns the ingress secrets.
 */
-func GetIngressSecretList(kubeClient *client.Client) (*api.SecretList, error) {
+func GetIngressSecretList(config *Config, kubeClient *client.Client) (*api.SecretList, error) {
 	// Query all secrets
 	secretList, err := kubeClient.Secrets(api.NamespaceAll).List(api.ListOptions{})
 
@@ -30,13 +23,13 @@ func GetIngressSecretList(kubeClient *client.Client) (*api.SecretList, error) {
 	var filtered []api.Secret
 
 	for _, secret := range secretList.Items {
-		if secret.Name == KeyIngressSecretName {
-			_, ok := secret.Data[KeyIngressAPIKey]
+		if secret.Name == config.APIKeySecret {
+			_, ok := secret.Data[config.APIKeySecretDataField]
 
 			if ok {
 				filtered = append(filtered, secret)
 			} else {
-				log.Printf("    Ingress secret for namespace (%s) is not usable: Missing '%s' key\n", secret.Namespace, KeyIngressAPIKey)
+				log.Printf("    Ingress secret for namespace (%s) is not usable: Missing '%s' key\n", secret.Namespace, config.APIKeySecretDataField)
 			}
 		}
 	}
@@ -49,11 +42,10 @@ func GetIngressSecretList(kubeClient *client.Client) (*api.SecretList, error) {
 /*
 UpdateSecretCacheForEvents updates the cache based on the secret events and returns if the changes warrant an nginx restart.
 */
-func UpdateSecretCacheForEvents(cache map[string]*api.Secret, events []watch.Event) bool {
+func UpdateSecretCacheForEvents(config *Config, cache map[string]*api.Secret, events []watch.Event) bool {
 	needsRestart := false
 
 	for _, event := range events {
-		// Coerce the event target to a Secret
 		secret := event.Object.(*api.Secret)
 		namespace := secret.Namespace
 
@@ -71,10 +63,10 @@ func UpdateSecretCacheForEvents(cache map[string]*api.Secret, events []watch.Eve
 
 		case watch.Modified:
 			cached, ok := cache[namespace]
-			apiKey, _ := secret.Data[KeyIngressAPIKey]
+			apiKey, _ := secret.Data[config.APIKeySecretDataField]
 
 			if ok {
-				cachedAPIKey, _ := cached.Data[KeyIngressAPIKey]
+				cachedAPIKey, _ := cached.Data[config.APIKeySecretDataField]
 
 				if (apiKey == nil && cachedAPIKey != nil) || (apiKey != nil && cachedAPIKey == nil) {
 					needsRestart = true
@@ -95,12 +87,12 @@ func UpdateSecretCacheForEvents(cache map[string]*api.Secret, events []watch.Eve
 		}
 
 		if _, ok := cache[namespace]; ok {
-			apiKey, _ := secret.Data[KeyIngressAPIKey]
+			apiKey, _ := secret.Data[config.APIKeySecretDataField]
 
 			if apiKey == nil {
-				log.Printf("    Secret has an %s value: no\n", KeyIngressAPIKey)
+				log.Printf("    Secret has an %s value: no\n", config.APIKeySecretDataField)
 			} else {
-				log.Printf("    Secret has an %s value: yes\n", KeyIngressAPIKey)
+				log.Printf("    Secret has an %s value: yes\n", config.APIKeySecretDataField)
 			}
 		}
 	}

--- a/ingress/types.go
+++ b/ingress/types.go
@@ -2,14 +2,31 @@ package ingress
 
 import (
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/labels"
 )
 
 /*
-Cache is the structure containing the ingress API Keys and the microservices pods cache
+Cache is the structure containing the ingress API Keys and the routable pods cache
 */
 type Cache struct {
 	Pods    map[string]*PodWithRoutes
 	Secrets map[string]*api.Secret
+}
+
+/*
+Config is the structure containing the configuration
+*/
+type Config struct {
+	// The secret name used to store the API Key for the namespace
+	APIKeySecret string
+	// The secret data field name to store the API Key for the namespace
+	APIKeySecretDataField string
+	// The name of the annotation used to find hosts to route
+	HostsAnnotation string
+	// The name of the annotation used to find paths to route
+	PathsAnnotation string
+	// The label selector used to identify routable objects
+	RoutableLabelSelector labels.Selector
 }
 
 /*


### PR DESCRIPTION
Host and path based routing, whether for external (ingress) or internal
purposes is largely the same.  So instead of continuing to tack on more
annotations and configuration items to this router, this commit makes
the touch points configurable so you can use the same code base to run
under multiple different roles.

We also renamed the following configuration/runtime items:

* The `ingress` secret name is now `routing` _(by default but is configurable)_
* The `publicPaths` annotation is now `routingPaths` _(by default but is configurable)_
* The `trafficHosts` annotation is now `routingHosts` _(by default but is configurable)_
* The `X-INGRESS-API-KEY` header is now `X-ROUTING-API-KEY` _(by default but is configurable)_
* The label selector `microservice=true` now defaults to `routable=true`

See: #11
Subtask _(renaming configuration annotations)_ link: https://github.com/30x/k8s-pods-ingress/issues/11#issuecomment-217002450
Subtask _(making the touch points configurable)_ link: https://github.com/30x/k8s-pods-ingress/issues/11#issuecomment-216591635